### PR TITLE
Remove expression "Login with" on login buttons

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -188,7 +188,7 @@ class PluginSinglesignonToolbox {
          $btn .= ' ';
       }
 
-      $btn .= sprintf(__sso('Login with %s'), $data['name']);
+      $btn .= sprintf(__sso('%s'), $data['name']);
       $btn .= '</a></span>';
       return $btn;
    }


### PR DESCRIPTION
Make the button label fully customizable and multilingual where the full name of the button will be defined in the plugin interface settings